### PR TITLE
pre-commit update github action

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ on:
   # every monday
   schedule:
     - cron: "0 7 * * 1"
-  # on demand  
+  # on demand
   workflow_dispatch:
 
 jobs:
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
       - uses: actions/setup-python@v2
-      
+
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      
+
       - uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -1,0 +1,26 @@
+name: Pre-commit auto-update
+
+on:
+  # every monday
+  schedule:
+    - cron: "0 7 * * 1"
+  # on demand  
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions/setup-python@v2
+      
+      - uses: browniebroke/pre-commit-autoupdate-action@main
+      
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: detect-private-key
     -   id: check-merge-conflict
     -   id: check-added-large-files
-    
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.1.9


### PR DESCRIPTION
## Pre-commit autoupdate with github action

## ✨ Context
Pre-commit helps to check code before committing and needs to get update.

## 🧠 Rationale behind the change

Uses github actions to run autoupdate for pre-commit

## Type of changes

- [X] New Feature (changes that introduce new functionality)


## 🛠 What does this PR implement
github action scritp to autoupdate pre-commit each monday
