### PR TITLE
✅ update mkdocs test

### DIFF
--- a/tests/test_create_template_no_mkdocs.py
+++ b/tests/test_create_template_no_mkdocs.py
@@ -11,3 +11,10 @@ def test_cookiecutter_mkdocs_files(cookies) -> None:  # type: ignore
 
     env_path = result.project_path / "docs/index.md"
     assert not env_path.is_file()
+
+    env_path = result.project_path / "pyproject.toml"
+    assert env_path.is_file()
+
+    with open(env_path) as f:
+        file_content = f.read()
+        assert "tool.poetry.group.docs.dependencies" not in file_content

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -14,7 +14,6 @@ python = "^{{ cookiecutter.compatible_python_versions }}"
 hydra-core = "^1.1.1"
 
 
-
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"
 
@@ -26,11 +25,13 @@ pytest = "^8.0.0"
 pytest-cov = "^4.1.0"
 pytest-mock = "^3.12.0"
 
+#{% if cookiecutter.mkdocs %}
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.5.3"
 mkdocs-material = "^9.5.7"
 mkdocstrings = {extras = ["python"], version = "^0.24.0"}
 pymdown-extensions = "^10.7"
+#{% endif %}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# Mkdocs test

## ✨ Context
when template is installed without mkdocs, the libs still in the pyproject.toml

## Type of changes

- [X] ✅ Tests (Unit tests, integration tests, end-to-end tests)
- [X] 👷 🔧 CI or Configuration Files


## 🛠 What does this PR implement

add condition to pyproject.toml to install mkdocs libs or not

## 🧪 How should this be tested?

- `poetry run pytest --cov`
