### PR TITLE
🔧 Remove mkdocs based on template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -35,7 +35,6 @@
     ".editorconfig",
     ".pre-commit-config.yaml",
     "codecov.yaml",
-    "docs/*",
-    "Makefile"
+    "docs/*"
   ]
 }

--- a/tests/test_create_template_no_mkdocs.py
+++ b/tests/test_create_template_no_mkdocs.py
@@ -13,9 +13,12 @@ def test_cookiecutter_mkdocs_files(cookies) -> None:  # type: ignore
         env_path = result.project_path / file_path
         assert not env_path.is_file()
 
-    env_path = result.project_path / "pyproject.toml"
-    assert env_path.is_file()
+    file_paths = ["pyproject.toml", "Makefile"]
+    text_check = ["tool.poetry.group.docs.dependencies", "mkdocs"]
 
-    with open(env_path) as f:
-        file_content = f.read()
-        assert "tool.poetry.group.docs.dependencies" not in file_content
+    for file_path, text in zip(file_paths, text_check, strict=False):
+        env_path = result.project_path / file_path
+        if env_path.is_file():
+            with open(env_path) as f:
+                file_content = f.read()
+                assert text not in file_content

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -41,6 +41,7 @@ pre-commit_update: ## Update pre-commit hooks
 	poetry run pre-commit clean
 	poetry run pre-commit autoupdate
 
+#{% if cookiecutter.mkdocs %}
 ####----Docs----####
 docs_view: ## Build and serve the documentation
 	@echo "🚀 Viewing documentation..."
@@ -48,6 +49,7 @@ docs_view: ## Build and serve the documentation
 
 docs_test: ## Test if documentation can be built without warnings or errors
 	@poetry run mkdocs build -s
+#{% endif %}
 
 ####----Checks----####
 check: ## Run code quality tools with pre-commit hooks.


### PR DESCRIPTION
# 🔧 Remove mkdocs based on template

## ✨ Context

When mkdocs is not needed all the diles and contect generated by cookie cutter has to remove mkdocs info.

is not happening at this moment

## Type of changes

- [X] 🐛 Bugfix (changes that fix a problem with the current behavior)
- [X] ✅ Tests (Unit tests, integration tests, end-to-end tests)
- [X] 👷 🔧 CI or Configuration Files


## 🛠 What does this PR implement

add mkdocs check into makefile to testing and change makefile

## 🧪 How should this be tested?

- `poetry run pytest --cov`
