### PR TITLE
pre-commit replace bandit with ruff

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -39,13 +39,12 @@ def test_cookiecutter_make_help(cookies):  # type: ignore
     """ensure the make help command runs without error"""
     result = cookies.bake()
 
-    make_proc = subprocess.Popen(
+    make_proc = subprocess.run(
         ["/usr/bin/make"],
-        shell=False,
+        shell=False,  # noqa: S603
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         cwd=result.project_path,
-    )  # nosec
-    # stdout, stderr are for debuggin
-    stdout, stderr = make_proc.communicate()
+        check=True,
+    )
     assert make_proc.returncode == 0

--- a/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
+++ b/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
@@ -54,6 +54,8 @@ select = [
     "PL",
     # isort
     "I",
+    # flake8-bandit
+    "S",
     # pyupgrade
     "UP",
     # ruff
@@ -61,7 +63,11 @@ select = [
     # tryceratops
     "TRY",
     ]
-ignore = ["E203"]
+ignore = [
+    "E203",
+        # bandit: Use of `assert` detected
+    "S101"
+    ]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []

--- a/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
+++ b/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
@@ -60,6 +60,8 @@ select = [
     "UP",
     # ruff
     "RUF",
+    # flake8-simplify
+    "SIM",
     # tryceratops
     "TRY",
     ]

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -30,14 +30,6 @@ repos:
         args:
           - --config-file=.code_quality/mypy.ini
 
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.8
-    hooks:
-      - id: bandit
-        args:
-          - -c
-          - .code_quality/bandit.yaml
-
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -50,3 +50,10 @@ repos:
       - id: detect-secrets
         name: 'detect-secrets-jupyter'
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.20.0
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [push]

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -2,16 +2,12 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-        exclude_types: [jupyter]
       - id: check-yaml
         exclude: ^(mkdocs\.yml|{{cookiecutter.repo_name}}/mkdocs\.yml)$
       - id: check-case-conflict
       - id: debug-statements
       - id: detect-private-key
       - id: check-merge-conflict
-      - id: check-ast
       - id: check-added-large-files
         args: [--maxkb=100000] # 100MB
 


### PR DESCRIPTION
# Replace Bandit with ruff in pre-commit

## ✨ Context

ruff has reimplemented the bandit rules[1], so it can be use that as a better-integrated tool. So enable all the bandit rules and selectively disable some across the codebase and some in just tests where they don't make sense (e.g. flagging use of assert ).


[1] Per astral-sh/ruff#1646 they've implemented nearly all of them, and the remaining ones aren't that important IMO.

## 🧠 Rationale behind the change

uses less tools in pre-commit and  get rid of the GitPython dependency, lees tools less security holes

## Type of changes

- [X] 🔥 Improvements (Minor refactoring, code changes or optimizations)
- [X] ✅ Tests (Unit tests, integration tests, end-to-end tests)
- [X] 👷 🔧 CI or Configuration Files


## 🛠 What does this PR implement

remove bandit form pre-commit and replace it using RUff Rules

change unit test to ignore warning detected by ruff

## 🧪 How should this be tested?

- `make check`

- `poetry run pytest --cov`
