### PR TITLE
🔥 remove test of make file

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -1,5 +1,4 @@
 import re
-import subprocess  # nosec
 
 
 def test_run_cookiecutter_result(cookies):  # type: ignore
@@ -33,18 +32,3 @@ def test_cookiecutter_generated_files(cookies):  # type: ignore
         re_bad.search(str(file_path)) is None
         for file_path in result.project_path.glob("*")
     )
-
-
-def test_cookiecutter_make_help(cookies):  # type: ignore
-    """ensure the make help command runs without error"""
-    result = cookies.bake()
-
-    make_proc = subprocess.run(
-        ["/usr/bin/make"],
-        shell=False,  # noqa: S603
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=result.project_path,
-        check=True,
-    )
-    assert make_proc.returncode == 0


### PR DESCRIPTION
# Remove unit test of makefile 

## ✨ Context

THe unit test of the makefile has security issues based con bandit.

## 🧠 Rationale behind the change

This test is not necesary so i will remove it

## Type of changes

- [X] 🐛 Bugfix (changes that fix a problem with the current behavior)
- [X] ✅ Tests (Unit tests, integration tests, end-to-end tests)

## 🛠 What does this PR implement

Remove `test_cookiecutter_make_help`unit test


## 🧪 How should this be tested?

- `poetry run pytest --cov`
- `pre-commit run -a`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes a unit test (`test_cookiecutter_make_help`) from the test suite due to identified security issues. The test was deemed unnecessary and has been deleted to improve security.

- **Bug Fixes**:
    - Removed a unit test that had security issues as identified by Bandit.
- **Tests**:
    - Deleted the `test_cookiecutter_make_help` unit test from the test suite.

<!-- Generated by sourcery-ai[bot]: end summary -->