### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
       # Run the linter.s
       - id: ruff


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the pre-commit configuration to use a newer version (v0.5.2) of the 'ruff' linter.

- **Chores**:
    - Updated the pre-commit hook for the 'ruff' linter to use version v0.5.2.

<!-- Generated by sourcery-ai[bot]: end summary -->