### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.2
+    rev: v0.5.4
     hooks:
       # Run the linter.s
       - id: ruff
@@ -24,7 +24,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.0
     hooks:
       - id: mypy
         args:
@@ -40,7 +40,7 @@ repos:
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.27.0
+    rev: v3.28.0
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the versions of several pre-commit hooks to their latest releases, ensuring the project uses the most recent tools and features.

- **Chores**:
    - Updated pre-commit hooks to newer versions: ruff to v0.5.4, mypy to v1.11.0, and commitizen to v3.28.0.

<!-- Generated by sourcery-ai[bot]: end summary -->