### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.2
+    rev: v0.6.3
     hooks:
       # Run the linter.s
       - id: ruff


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the pre-commit configuration to use the latest version of the Ruff linter.

Build:
- Update the pre-commit hook for the Ruff linter to version v0.6.3.

<!-- Generated by sourcery-ai[bot]: end summary -->