### PR TITLE
📝 change pipx for UV

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Table of Contents
 
 It is highly recommended to use a python version manager like [Pyenv] and this project is set to use [Poetry] >= 1.8 to manage the dependencies and the environment.
 
-**Note:** [Poetry] >= 1.8 should always be installed in a dedicated virtual environment to isolate it from the rest of your system. [why?](https://python-poetry.org/docs/#installation)
+**Note:** [Poetry] >= 1.8 should always be installed in a dedicated virtual environment to isolate it from the rest of your system. [why?](https://python-poetry.org/docs/#installation), I recommend using [UV] to install poetry in an isolated environment.
+
+```bash
 
 🌟 Check how to setup your environment: <https://joserzapata.github.io/data-science-project-template/local_setup/>
 
@@ -64,6 +66,10 @@ It is highly recommended to use a python version manager like [Pyenv] and this p
 
 ```bash title="install cruft"
 pip install --user cruft # Install `cruft` on your path for easy access
+
+# Or Install with UV
+
+uv tool install cruft # Install cruft in a isolated environment
 ```
 
 ```shell title="create project"
@@ -74,6 +80,10 @@ cruft create https://github.com/JoseRZapata/data-science-project-template
 
 ```shell title="install cookiecutter"
 pip install --user cookiecutter # Install `cookiecutter` on your path for easy access
+
+# Or Install with UV
+
+uv tool install cookiecutter # Install cruft in a isolated environment
 ```
 
 ```shell title="create project"
@@ -343,3 +353,4 @@ test                  Test the code with pytest and coverage
 [Pytest]: https://docs.pytest.org/en/latest/
 [pyupgrade]: https://github.com/asottile/pyupgrade
 [Ruff]: https://docs.astral.sh/ruff/
+[UV]: https://docs.astral.sh/uv/

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -35,6 +35,8 @@ I setup my local development environment using the following steps:
 
 General Tools that I use to develop Python projects, The most important is [Poetry] and all this tools are installed using [UV] to have this tools in isolated environments, because applications runs in its own virtual environment to avoid dependencies conflicts and they are available everywhere.
 
+[UV Highligths](https://github.com/astral-sh/uv?tab=readme-ov-file#highlights)
+
 1. [Poetry] to manage the dependencies and the virtual environment of the project.
       - `uv tool install poetry`
 2. [Cruft] allows you to maintain all the necessary boilerplate for packaging and building projects separate from the code you intentionally write. Fully compatible with existing Cookiecutter templates.

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -16,43 +16,33 @@ I setup my local development environment using the following steps:
       - Linux: `curl https://pyenv.run | bash`
       - MAC: `brew install pyenv`
       - **Check the installation version** executing in terminal: `pyenv --version` for help go to [pyenv installation help](https://github.com/pyenv/pyenv?tab=readme-ov-file#set-up-your-shell-environment-for-pyenv)
-4. Install [Python] using [Pyenv] , at this time I am using Python 3.11
+4. Install [Python] using [Pyenv] , at this time I am using Python 3.11 (in Future, i recommend to use [UV] to manage the python versions)
       - `pyenv install 3.11` # Install Python 3.11 in computer
       - `pyenv global 3.11` # Set Python 3.11 as global version
       - **Check the installation version** executing in terminal: `python --version`
-5. Install locally [Pipx] to Install and Run Python Applications in Isolated Environments
+5. Install locally [UV] to Install and Run Python Applications in Isolated Environments
       - Linux:
 
-        ```bash title="Install pipx in Linux"
-        pip install --user pipx
-        python3 -m pipx ensurepath
+        ```bash title="Install uv in Linux or MACOS"
+        curl -LsSf https://astral.sh/uv/install.sh | sh
         ```
 
-        - Check the installation version executing in terminal: `pipx --version`
-
-      - MAC:
-
-        ```bash title="Install pipx in Mac os"
-        brew install pipx
-        pipx ensurepath
-        ```
-
-        - Check the installation version executing in terminal: `pipx --version`
+        - Check the installation version executing in terminal: `uv version`
 
 ## 🐍 General Python tools
 
-General Tools that I use to develop Python projects, The most important is [Poetry] and all this tools are installed using [Pipx] to have this tools in isolated environments, because applications runs in its own virtual environment to avoid dependencies conflicts and they are available everywhere.
-
-[When pipx is typically used?](https://python.land/virtual-environments/pipx#When_pipx_is_typically_used)
+General Tools that I use to develop Python projects, The most important is [Poetry] and all this tools are installed using [UV] to have this tools in isolated environments, because applications runs in its own virtual environment to avoid dependencies conflicts and they are available everywhere.
 
 1. [Poetry] to manage the dependencies and the virtual environment of the project.
-      - `pipx install poetry`
+      - `uv tool install poetry`
 2. [Cruft] allows you to maintain all the necessary boilerplate for packaging and building projects separate from the code you intentionally write. Fully compatible with existing Cookiecutter templates.
-      - `pipx install cruft`
+      - `uv tool install cruft`
 3. (optional) [Pip-audit] to local check the security of the dependencies of the project.
-      - `pipx install pip-audit`
+      - `uv tool install pip-audit`
 4. (optional) [Actionlint] to check the syntax of the GitHub Actions configuration files of the project.
-      - `pipx install actionlint`
+      - `uv tool install actionlint`
+
+**Note:** [UV] is a tool that wants to replace the need of [Pyenv], [Poetry] and other ones. So is very possible that in the future I will use [UV] to manage the python versions, enviroments and dependencies.
 
 ## 📁 Start a new data science project
 
@@ -83,8 +73,8 @@ General Tools that I use to develop Python projects, The most important is [Poet
 [Git]: https://git-scm.com/
 [Make]: https://www.gnu.org/software/make/manual/make.html
 [Pip-audit]: https://github.com/pypa/pip-audit
-[Pipx]: https://pipx.pypa.io/stable/
 [Poetry]: https://python-poetry.org/docs/
 [Pyenv]: https://github.com/pyenv/pyenv?tab=readme-ov-file#installation
 [Python]: https://www.python.org/downloads/
+[UV]: https://docs.astral.sh/uv/
 [WSL]: https://docs.microsoft.com/en-us/windows/wsl/install

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -16,7 +16,9 @@ I setup my local development environment using the following steps:
       - Linux: `curl https://pyenv.run | bash`
       - MAC: `brew install pyenv`
       - **Check the installation version** executing in terminal: `pyenv --version` for help go to [pyenv installation help](https://github.com/pyenv/pyenv?tab=readme-ov-file#set-up-your-shell-environment-for-pyenv)
-4. Install [Python] using [Pyenv] , at this time I am using Python 3.11 (in Future, i recommend to use [UV] to manage the python versions)
+4. Install [Python] using [Pyenv], at this time I am using Python 3.11  
+   (In the future, I recommend using [UV] to manage Python versions. UV is a faster,  
+   more efficient alternative to traditional package managers and virtual environments.)
       - `pyenv install 3.11` # Install Python 3.11 in computer
       - `pyenv global 3.11` # Set Python 3.11 as global version
       - **Check the installation version** executing in terminal: `python --version`
@@ -42,7 +44,7 @@ General Tools that I use to develop Python projects, The most important is [Poet
 4. (optional) [Actionlint] to check the syntax of the GitHub Actions configuration files of the project.
       - `uv tool install actionlint`
 
-**Note:** [UV] is a tool that wants to replace the need of [Pyenv], [Poetry] and other ones. So is very possible that in the future I will use [UV] to manage the python versions, enviroments and dependencies.
+**Note:** [UV] is a tool that wants to replace the need of [Pyenv], [Poetry] and other ones. So is very possible that in the future I will use [UV] to manage the python versions, environments and dependencies.
 
 ## 📁 Start a new data science project
 


### PR DESCRIPTION
# Change pipx for UV

## ✨ Context

in the documentacion was recommenden to use pipx to install some python tools in isolated enviroments, but at sep/2024 UV replaces the use of pipx and other tools

## 🧠 Rationale behind the change

UV replaces pipx, and UV is very fast and replaces pyenv, poetry and venv, so in future i will change  this tools with uv

## Type of changes

- [X] 📝 Documentation


## 🛠 What does this PR implement

documentation change of pipx for UV

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace pipx with UV in the documentation for managing Python tools in isolated environments, reflecting the transition to UV as a more comprehensive tool for managing Python versions, environments, and dependencies.

Documentation:
- Update documentation to replace references to pipx with UV for installing and managing Python tools in isolated environments.

<!-- Generated by sourcery-ai[bot]: end summary -->