### PR TITLE
Feature/length ruff

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -5,9 +5,7 @@ def test_run_cookiecutter_result(cookies):  # type: ignore
     """Runs cookiecutter and checks a couple of things"""
     project_name = "data science project template"
     repo_name = "data-science-project-template"
-    result = cookies.bake(
-        extra_context={"project_name": project_name, "repo_name": repo_name}
-    )
+    result = cookies.bake(extra_context={"project_name": project_name, "repo_name": repo_name})
 
     assert result.exit_code == 0
     assert result.exception is None
@@ -28,7 +26,4 @@ def test_cookiecutter_generated_files(cookies):  # type: ignore
     re_bad = re.compile(r"{{\s?cookiecutter\..*?}}")
     result = cookies.bake()
 
-    assert all(
-        re_bad.search(str(file_path)) is None
-        for file_path in result.project_path.glob("*")
-    )
+    assert all(re_bad.search(str(file_path)) is None for file_path in result.project_path.glob("*"))

--- a/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
+++ b/{{cookiecutter.repo_name}}/.code_quality/ruff.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 #same as black
-line-length = 88
+line-length = 100
 indent-width = 4
 
 # Assume Python 3.10


### PR DESCRIPTION
## ✨ Context

Add 100 line length to ruff formater

## 🧠 Rationale behind the change

At this time wider screens are availabre and 100 length are confortable
## Type of changes

- [X] 👷 🔧 CI or Configuration Files

## 🛠 What does this PR implement

This pull request includes several formatting changes and a configuration update. The most important changes are:

Formatting improvements in test files:

* [`tests/test_create_template.py`](diffhunk://#diff-bbbe72100d5794984d98293d04a38c801afb7e0590c16ec16ae33743a7ed7d75L8-R8): Simplified the formatting of `cookies.bake` calls in `test_run_cookiecutter_result` and `test_cookiecutter_generated_files` functions. [[1]](diffhunk://#diff-bbbe72100d5794984d98293d04a38c801afb7e0590c16ec16ae33743a7ed7d75L8-R8) [[2]](diffhunk://#diff-bbbe72100d5794984d98293d04a38c801afb7e0590c16ec16ae33743a7ed7d75L31-R29)

Configuration update:

* [`{{cookiecutter.repo_name}}/.code_quality/ruff.toml`](diffhunk://#diff-81e3c73fdfbc64788e3a61b19d734278eac60665ae1ffa89a8d287e8ffda95c7L32-R32): Increased the `line-length` configuration from 88 to 100.# Title

## Summary by Sourcery

CI:
- Update the ruff configuration to increase the line-length from 88 to 100.