### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.3
+    rev: v0.8.4
     hooks:
       # Run the linter.s
       - id: ruff
@@ -27,7 +27,7 @@ repos:
           - .code_quality/ruff.toml          
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.0
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hooks to their latest versions.

Build:
- Update Ruff from v0.8.3 to v0.8.4.
- Update Mypy from v1.13.0 to v1.14.0.