### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.2
+    rev: v0.9.3
     hooks:
       # Run the linter.s
       - id: ruff
@@ -43,7 +43,7 @@ repos:
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.1.0
+    rev: v4.1.1
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hooks.

Build:
- Update Ruff from v0.9.2 to v0.9.3.
- Update Commitizen from v4.1.0 to v4.1.1.