### PR TITLE
fix auto update pre-commit

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -19,6 +19,7 @@ jobs:
         uses: brokenpip3/action-pre-commit-update@0.0.2
         with:
           github-token: ${{ secrets.PAT }}
+          update-freeze: false
       - name: Add label
         uses: actions/github-script@v7
         with:

--- a/{{cookiecutter.repo_name}}/.github/workflows/pre-commit_autoupdate.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/pre-commit_autoupdate.yml
@@ -16,9 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Update pre-commit hooks
-        uses: brokenpip3/action-pre-commit-update@0.0.1
+        uses: brokenpip3/action-pre-commit-update@0.0.2
         with:
           github-token: ${{ secrets.PAT }}
+          update-freeze: false
       - name: Add label
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
# Fix auto-update

## ✨ Context

Autoupdate CI github action is adding a hash value instead of the version of the pre-commit hooks.

## 🧠 Rationale behind the change

Pre-commit hook about check secrets values are falling because of that hash numbers

## Type of changes

- [X] 🐛 Bugfix (changes that fix a problem with the current behavior)
- [X] 👷 🔧 CI or Configuration Files

## 🛠 What does this PR implement

This pull request includes updates to the pre-commit auto-update workflows in the `.github/workflows/pre-commit_autoupdate.yml` and `{{cookiecutter.repo_name}}/.github/workflows/pre-commit_autoupdate.yml` files. The most important changes include updating the version of the `brokenpip3/action-pre-commit-update` action and adding a new parameter to disable the update freeze.

Updates to pre-commit auto-update workflows:

* Updated the `brokenpip3/action-pre-commit-update` action from version `0.0.1` to `0.0.2` in both workflow files.
* Added the `update-freeze: false` parameter to the `brokenpip3/action-pre-commit-update` action configuration in both workflow files.

## 🙈 Missing

If there are things that are requested in the task and were not implemented, list them here

## 🧪 How should this be tested?

Run CI

## Summary by Sourcery

Updates the pre-commit auto-update workflow to fix an issue where the wrong version of pre-commit hooks was being used. This was achieved by updating the `brokenpip3/action-pre-commit-update` action and disabling the update freeze.

Bug Fixes:
- Fixes an issue where the auto-update CI GitHub Action was adding a hash value instead of the version for pre-commit hooks, causing secret checks to fail.

CI:
- Updates the pre-commit auto-update workflow to use version 0.0.2 of the `brokenpip3/action-pre-commit-update` action.
- Disables the update freeze in the pre-commit auto-update workflow.