### PR TITLE
chore(pre-commit): auto update hooks

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         exclude: ^(mkdocs\.yml|{{cookiecutter.repo_name}}/mkdocs\.yml)$
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 895ebb389825c29bd4e0addcf7579d6c69d199cc  # frozen: v0.9.6
+    rev: v0.9.7
     hooks:
       # Run the linter
       - id: ruff
@@ -27,14 +27,14 @@ repos:
           - .code_quality/ruff.toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: f40886d54c729f533f864ed6ce584e920feb0af7  # frozen: v1.15.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         args:
           - --config-file=.code_quality/mypy.ini
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # frozen: v1.5.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         exclude: ^(poetry\.lock|\.cruft\.json|.*\.ipynb)$
@@ -43,7 +43,7 @@ repos:
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 8519ca470e88f8c7eb30dfe31cad2b0dd8acfea2  # frozen: v4.2.1
+    rev: v4.2.2
     hooks:
       - id: commitizen
       - id: commitizen-branch


### PR DESCRIPTION
This is an automation, check the updated pre-commit hooks and target files

## Summary by Sourcery

Update pre-commit hooks to the latest versions.

Enhancements:
- Update pre-commit hooks to the latest versions, including ruff, mypy, detect-secrets and commitizen.

Chores:
- Update pre-commit hooks to the latest versions.