### PR TITLE
ci: migrate workflows from PAT to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_METHOD: squash
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_LABELS: automerge   # label to trigger automerge

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,12 +6,15 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_METHOD: squash
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_LABELS: automerge   # label to trigger automerge

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: ./site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
 
@@ -31,5 +33,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -26,7 +26,7 @@ jobs:
         name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           yaml-file: .github/labels.yml
           dry-run: ${{ github.event_name == 'pull_request' }}
           exclude: |

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       -
         name: Checkout
@@ -23,7 +26,7 @@ jobs:
         name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v6
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml
           dry-run: ${{ github.event_name == 'pull_request' }}
           exclude: |

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: TimonVS/pr-labeler-action@v5
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
           configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -1,6 +1,4 @@
 name: Pre-commit auto-update
-# PAT github secret has to be created with repo scope
-# add the secret to the repo settings
 on:
   # every monday
   schedule:
@@ -11,6 +9,10 @@ on:
 jobs:
   pre-commit-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     name:
     steps:
       - name: Checkout
@@ -18,12 +20,12 @@ jobs:
       - name: Update pre-commit hooks
         uses: brokenpip3/action-pre-commit-update@0.0.5
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           update-freeze: false
       - name: Add label
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Update pre-commit hooks
         uses: brokenpip3/action-pre-commit-update@0.0.5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           update-freeze: false
       - name: Add label
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,

--- a/.github/workflows/update_template_deps.yml
+++ b/.github/workflows/update_template_deps.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           commit-message: "chore: update template dependencies"
           title: "chore: update template dependencies"
           body: |
@@ -41,7 +41,7 @@ jobs:
       - name: Add label
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,

--- a/.github/workflows/update_template_deps.yml
+++ b/.github/workflows/update_template_deps.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update template dependencies"
           title: "chore: update template dependencies"
           body: |
@@ -41,7 +41,7 @@ jobs:
       - name: Add label
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,

--- a/docs/setup_tokens.es.md
+++ b/docs/setup_tokens.es.md
@@ -16,14 +16,14 @@ En los workflows, usar:
 
 ```yaml
 with:
-  github-token: ${{ secrets.GITHUB_TOKEN }}
+  github-token: ${{ github.token }}
 ```
 
 o:
 
 ```yaml
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ github.token }}
 ```
 
 Además, definir permisos explícitos en cada workflow/job cuando aplique, por ejemplo:

--- a/docs/setup_tokens.es.md
+++ b/docs/setup_tokens.es.md
@@ -1,32 +1,73 @@
-# 🔑 Configurar Tokens
+# 🔑 Configurar tokens para GitHub Actions
 
-Algunas de las GitHub Actions requieren claves de token que se establezcan como secretos en el repositorio de GitHub. Los siguientes tokens son requeridos:
+Esta plantilla ahora usa **`GITHUB_TOKEN` por defecto** en la mayoría de workflows.
 
-## GitHub Action secrets.PAT
+`GITHUB_TOKEN` se crea automáticamente en cada ejecución de GitHub Actions, así que normalmente **no** necesitas crear un PAT manual.
 
-Este es el token de acceso personal para el repositorio de GitHub y se usa para:
+## 1) Recomendación por defecto: `GITHUB_TOKEN`
 
-- Subir la documentación de MKDocs a la rama `gh-pages`.
-- Subir la actualización automática de pre-commit a la rama `main`.
+### Qué configurar en el repositorio
 
-Cómo configurar el secrets.PAT:
+1. Ir a **Settings → Actions → General → Workflow permissions**.
+2. Seleccionar **Read and write permissions**.
+3. Activar **Allow GitHub Actions to create and approve pull requests** (requerido para workflows de automatización de PRs).
 
-- Crear en github un [Personal Access Token (PAT)](https://github.com/settings/tokens?type=beta), para el repositorio específico. [Cómo](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-- Darle acceso de lectura/escritura a "Contents", "Pull Requests" y "Workflows" en la sección "Repository Permissions".
-- Agregar el PAT a los secretos del repositorio. Ir a la configuración del repositorio > Secrets and variables > Actions. Luego en Repository secrets agregar un nuevo secreto de repositorio y nombrarlo `PAT` y pegar el token.
-- Debes permitir explícitamente a GitHub Actions crear pull requests. Esta configuración se encuentra en la configuración del repositorio bajo Actions > General > Workflow permissions. Seleccionar `Read repository contents and packages permissions`
+En los workflows, usar:
 
-## CODECOV_TOKEN
+```yaml
+with:
+  github-token: ${{ secrets.GITHUB_TOKEN }}
+```
 
-Este es el token para codecov. Se usa para subir el reporte de cobertura a codecov. Puedes obtenerlo desde codecov.io. No es requerido para desarrollo local.
-<https://docs.codecov.com/docs/quick-start>
+o:
 
-Debes agregar este secreto al repositorio de github. Cómo agregar codecov al repositorio de github: <https://docs.codecov.com/docs/adding-the-codecov-token#github-actions>
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Además, definir permisos explícitos en cada workflow/job cuando aplique, por ejemplo:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+```
+
+## 2) ¿Cuándo sí necesitas un PAT?
+
+Usa PAT (o token de GitHub App) solo en casos avanzados, por ejemplo:
+
+- Cuando necesitas que PRs/commits creados por automatización disparen otros workflows y las restricciones de `GITHUB_TOKEN` lo impiden.
+- Cuando necesitas acceso a **otro repositorio** (operaciones cross-repo).
+- Cuando una acción requiere scopes específicos no cubiertos por los permisos actuales de `GITHUB_TOKEN`.
+
+Si hace falta, crea un secret de repositorio llamado `PAT`.
+
+## 3) Fallback temporal de migración (opcional)
+
+Mientras migras repositorios existentes, puedes usar temporalmente:
+
+```yaml
+${{ secrets.PAT || github.token }}
+```
+
+Así mantienes compatibilidad con repos viejos mientras eliminas dependencia de PAT.
+
+## 4) CODECOV_TOKEN
+
+`CODECOV_TOKEN` sigue siendo necesario para workflows de subida de cobertura a Codecov (según tu configuración).
+
+- <https://docs.codecov.com/docs/quick-start>
+- <https://docs.codecov.com/docs/adding-the-codecov-token#github-actions>
 
 ---
 
 ## Referencias
 
+- <https://docs.github.com/en/actions/security-guides/automatic-token-authentication>
+- <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions>
+- <https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow>
 - <https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions>
-- <https://github.com/peter-evans/create-pull-request/issues/2443>
-- <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token>
+- <https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/>

--- a/docs/setup_tokens.es.md
+++ b/docs/setup_tokens.es.md
@@ -1,6 +1,6 @@
 # 🔑 Configurar tokens para GitHub Actions
 
-Esta plantilla ahora usa **`GITHUB_TOKEN` por defecto** en la mayoría de workflows.
+Esta plantilla ahora usa **`GITHUB_TOKEN` por defecto** en la mayoría de los workflows.
 
 `GITHUB_TOKEN` se crea automáticamente en cada ejecución de GitHub Actions, así que normalmente **no** necesitas crear un PAT manual.
 

--- a/docs/setup_tokens.md
+++ b/docs/setup_tokens.md
@@ -1,4 +1,4 @@
-# 🔑 Setup tokens for GitHub Actions
+# 🔑 Set up tokens for GitHub Actions
 
 This template now uses **`GITHUB_TOKEN` by default** for most workflows.
 

--- a/docs/setup_tokens.md
+++ b/docs/setup_tokens.md
@@ -16,14 +16,14 @@ In workflows, use:
 
 ```yaml
 with:
-  github-token: ${{ secrets.GITHUB_TOKEN }}
+  github-token: ${{ github.token }}
 ```
 
 or:
 
 ```yaml
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ github.token }}
 ```
 
 Also set explicit permissions in each workflow/job when needed, for example:

--- a/docs/setup_tokens.md
+++ b/docs/setup_tokens.md
@@ -1,32 +1,73 @@
-# 🔑 Setup Tokens
+# 🔑 Setup tokens for GitHub Actions
 
-Some of the github actions require token keys to be set as secrets in the github repository. The following tokens are required:
+This template now uses **`GITHUB_TOKEN` by default** for most workflows.
 
-## Github Action secrets.PAT
+`GITHUB_TOKEN` is automatically created by GitHub Actions on each run, so you usually **do not** need to create a custom PAT secret.
 
-This is the personal access token for the github repository and It is used to:
+## 1) Recommended default: `GITHUB_TOKEN`
 
-- Push the MKDocs documentation to the `gh-pages` branch.
-- Push the pre-commit autoupdate to the `main` branch.
+### What to configure in the repository
 
-How to configure the secrets.PAT:
+1. Go to **Settings → Actions → General → Workflow permissions**.
+2. Select **Read and write permissions**.
+3. Enable **Allow GitHub Actions to create and approve pull requests** (required for PR automation workflows).
 
-- Create in github a [Personal Access Token (PAT)](https://github.com/settings/tokens?type=beta),for the specific repository. [How](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-- Give it read/write access to "Contents", "Pull Requests" and "Workflows" under the "Repository Permissions" section.
-- Add de PAT to the repository secrets. Go to the repository settings > Secrets and variables > Actions. THen in Repository secrets add a new repository secret and Name it `PAT` and paste the token.
-- You must explicitly allow GitHub Actions to create pull requests. This setting can be found in a repository's settings under Actions > General > Workflow permissions. select `Read repository contents and packages permissions`
+In workflows, use:
 
-## CODECOV_TOKEN
+```yaml
+with:
+  github-token: ${{ secrets.GITHUB_TOKEN }}
+```
 
-This is the token for codecov. It is used to upload the coverage report to codecov. You can get it from codecov.io. It is not required for local development.
-<https://docs.codecov.com/docs/quick-start>
+or:
 
-You have to add this secret to the github repository. How to add codecov to the github repository: <https://docs.codecov.com/docs/adding-the-codecov-token#github-actions>
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Also set explicit permissions in each workflow/job when needed, for example:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+```
+
+## 2) When is a PAT still needed?
+
+Use a PAT (or GitHub App token) only for advanced cases, such as:
+
+- You need automation-created PRs/commits to trigger additional workflows in a way that `GITHUB_TOKEN` restrictions prevent.
+- You need to access **another repository** (cross-repo operations).
+- An action feature explicitly requires scopes not available with your current `GITHUB_TOKEN` permissions.
+
+If needed, create a repository secret named `PAT`.
+
+## 3) Transitional fallback (optional)
+
+If you are migrating existing repositories, you can temporarily use:
+
+```yaml
+${{ secrets.PAT || github.token }}
+```
+
+This keeps old repos working while you remove PAT dependencies.
+
+## 4) CODECOV_TOKEN
+
+`CODECOV_TOKEN` is still required for Codecov upload workflows (depending on your Codecov setup).
+
+- <https://docs.codecov.com/docs/quick-start>
+- <https://docs.codecov.com/docs/adding-the-codecov-token#github-actions>
 
 ---
 
 ## References
 
+- <https://docs.github.com/en/actions/security-guides/automatic-token-authentication>
+- <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions>
+- <https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow>
 - <https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions>
-- <https://github.com/peter-evans/create-pull-request/issues/2443>
-- <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token>
+- <https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/>


### PR DESCRIPTION
## ✨ Context

This updates GitHub Actions authentication in the template to use `GITHUB_TOKEN` by default instead of relying on a repository `PAT` secret.

Since this repository is the source template propagated via `cruft update`, the goal is to reduce token-maintenance overhead and avoid failures in downstream repos when `PAT` is missing or expired.

## 🧠 Rationale behind the change

- `GITHUB_TOKEN` is generated automatically for each workflow run and is the recommended default in GitHub Actions.
- Explicit `permissions` were added so write operations remain reliable with modern default read-only token policies.
- PAT is still documented for advanced cases (cross-repo operations or workflow-chaining constraints), but not required by default.

Trade-off:
- Some automation chains that depend on PAT-triggered follow-up workflow behavior may differ when using only `GITHUB_TOKEN`. This is documented in the updated setup docs.

## Type of changes

- [ ] ✨ New Feature (changes that introduce new functionality)
- [ ] 🐛 Bugfix (changes that fix a problem with the current behavior)
- [ ] 💥 Breaking Change (Changes that radically modify current behavior and may be problematic)
- [ ] ⚗️  Experiments (A notebook with experimentation results)
- [x] 📝 Documentation
- [x] 🔥 Improvements (Minor refactoring, code changes or optimizations)
- [ ] ✅ Tests (Unit tests, integration tests, end-to-end tests)
- [x] 👷 🔧 CI or Configuration Files
- [ ] Other (Please describe)

## 🛠 What does this PR implement

### Workflow updates
- `.github/workflows/labels.yml`
  - Move from `secrets.PAT` to `secrets.GITHUB_TOKEN`
  - Add explicit permissions (`contents: read`, `issues: write`)

- `.github/workflows/pre-commit_autoupdate.yml`
  - Move from `secrets.PAT` to `secrets.GITHUB_TOKEN`
  - Add explicit permissions (`contents: write`, `pull-requests: write`, `issues: write`)
  - Remove outdated PAT-only comments

- `.github/workflows/automerge.yml`
  - Move from `secrets.PAT` to `secrets.GITHUB_TOKEN`
  - Add explicit permissions (`contents: write`, `pull-requests: write`)

- `.github/workflows/update_template_deps.yml`
  - Move from `secrets.PAT` to `secrets.GITHUB_TOKEN` for both PR creation and labeling
  - Existing write permissions retained

- `.github/workflows/docs.yml`
  - Move from `secrets.PAT` to `secrets.GITHUB_TOKEN`
  - Add explicit `contents: write` permission

### Documentation updates
- `docs/setup_tokens.md`
- `docs/setup_tokens.es.md`

Both docs now describe:
- `GITHUB_TOKEN` as default
- required repo settings in **Actions → General**
- explicit workflow permissions examples
- when PAT is still needed
- optional transitional fallback (`${{ secrets.PAT || github.token }}`)
- CODECOV token note and references

## 🙈 Missing

- No migration to GitHub App tokens in this PR.
- No downstream repo rollout in this PR (this repo is the source template; rollout occurs via `cruft update`).

## 🧪 How should this be tested?

1. Lint workflows:
   - `actionlint -color`
2. Validate docs changes:
   - Review `docs/setup_tokens.md` and `docs/setup_tokens.es.md`
3. Trigger relevant workflows in a test branch/repo to confirm behavior:
   - `labels.yml`
   - `pre-commit_autoupdate.yml`
   - `automerge.yml`
   - `update_template_deps.yml`
   - `docs.yml`
4. (Optional downstream validation) run `cruft update` in a child repo and verify workflow files sync correctly.

## Summary by Sourcery

Migrate GitHub Actions workflows in the template to use the built-in GITHUB_TOKEN with explicit permissions and update token setup documentation accordingly.

CI:
- Switch all relevant workflows from using the PAT repository secret to GITHUB_TOKEN and add explicit write/read permissions per job.

Documentation:
- Rewrite English and Spanish token setup guides to document GITHUB_TOKEN as the default, clarify required repository settings and permissions, outline advanced PAT/GitHub App use cases, and retain CODECOV token guidance.