### PR TITLE
ci: ✨ add dependabot config and staggered workflows for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "00:00"
+      timezone: "UTC"
     groups:
       python-packages:
         patterns:
@@ -21,6 +24,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "00:00"
+      timezone: "UTC"
     commit-message:
       prefix: ⬆
     labels:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,8 @@
 name: automerge
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 1-6' # Daily at 08:00 UTC, Mon-Sat
+    - cron: '0 * * * 0'   # Hourly on Sunday to catch up with staggered PR-creating jobs
   workflow_dispatch:
 jobs:
   automerge:

--- a/.github/workflows/update_template_workflows.yml
+++ b/.github/workflows/update_template_workflows.yml
@@ -2,7 +2,7 @@ name: Update Template Workflows
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # Run weekly on Sunday at midnight
+    - cron: "0 1 * * 0" # Run weekly on Sunday at 01:00 UTC (staggered 1h after update_template_deps.yml / Dependabot to avoid stale-branch collisions)
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] - 2026-08-15
+
+### Added 🚀
+
+- Added Dependabot configuration for automatic GitHub Actions version updates in both root and template workflows (with staggered schedules to avoid collisions)
+- Added script `scripts/update_template_workflows.py` to update GitHub Actions references in template workflows
+- Added workflow `.github/workflows/update_template_workflows.yml` to run the update script weekly
+- Added pre-commit hook `check-dependabot` to validate Dependabot configuration before commit
+- Updated `.github/workflows/automerge.yml` to run hourly on Sundays and daily Monday-Saturday, using `github.token` and proper permissions
+- Updated template's `.github/dependabot.yml` and `.github/workflows/automerge.yml` to match root configuration
+
+### Changed 💥
+
+- Staggered cron schedules: Dependabot and update_template_deps at 00:00 UTC Sunday, update_template_workflows at 01:00 UTC Sunday, automerge hourly on Sunday and daily 08:00 UTC Mon-Sat
 
 ## [1.3.0] - 2026-02-22
 
@@ -20,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 💥
 
 - Updated `.github/workflows/docs.yml` to trigger on changes to `mkdocs.yml`.
-
-## [Released]
 
 ## [1.2.0] - 2025-11-29
 

--- a/docs/github_actions/automerge.es.md
+++ b/docs/github_actions/automerge.es.md
@@ -11,7 +11,8 @@ Este flujo de trabajo de GitHub Action automatiza la fusión de pull requests et
 ### Disparadores (`on`)
 
 - **`schedule`**:
-    - Se ejecuta automáticamente diariamente a las 08:00 UTC (según el cron schedule: `0 8 * * *`).
+    - Se ejecuta automáticamente **cada hora los domingos** (UTC) para capturar los jobs escalonados de creación de PRs (`0 * * * 0`).
+    - Se ejecuta diariamente a las 08:00 UTC de lunes a sábado (`0 8 * * 1-6`).
 - **`workflow_dispatch`**:
     - Permite la ejecución manual del flujo de trabajo a través de la interfaz de GitHub Actions.
 
@@ -36,3 +37,18 @@ Este flujo de trabajo de GitHub Action automatiza la fusión de pull requests et
 ---
 
 En resumen, este flujo de trabajo simplifica el proceso de fusión de pull requests al fusionar automáticamente aquellos etiquetados con `automerge` usando el método `squash`. Puede ejecutarse diariamente o manualmente, asegurando flexibilidad y eficiencia en el proceso de desarrollo.
+
+---
+
+## Configuración Requerida del Repositorio para Workflows de PR Automatizados
+
+Para que el workflow de automerge (y otros PRs creados por bots como Dependabot, `update_template_deps`, `update_template_workflows`) ejecuten sus checks de CI **automáticamente sin aprobación manual**, debes configurar lo siguiente en el **repositorio de tu proyecto generado**:
+
+1. Ve a **Settings → Actions → General**
+2. En **"Fork pull request workflows from outside collaborators"**, selecciona:
+   - **"Require approval for first-time contributors who are new to GitHub"** (recomendado), o
+   - **"Read‑only"** (si confías en todos los colaboradores)
+
+Sin esta configuración, los PRs creados por bots mostrarán **"X workflows awaiting approval"** y sus checks permanecerán bloqueados hasta que un mantenedor apruebe manualmente cada ejecución.
+
+Esta configuración solo necesita hacerse una vez por repositorio generado.

--- a/docs/github_actions/automerge.md
+++ b/docs/github_actions/automerge.md
@@ -11,7 +11,8 @@ This GitHub Action workflow automates the merging of pull requests labeled with 
 ### Triggers (`on`)
 
 - **`schedule`**:
-    - Automatically runs daily at 08:00 UTC (according to the cron schedule: `0 8 * * *`).
+    - Automatically runs **every hour on Sundays** (UTC) to catch staggered PR-creating jobs (`0 * * * 0`).
+    - Runs daily at 08:00 UTC Monday–Saturday (`0 8 * * 1-6`).
 - **`workflow_dispatch`**:
     - Allows manual execution of the workflow via the GitHub Actions interface.
 
@@ -36,3 +37,18 @@ This GitHub Action workflow automates the merging of pull requests labeled with 
 ---
 
 In summary, this workflow simplifies the process of merging pull requests by automatically merging those labeled with `automerge` using the `squash` method. It can be executed daily or manually, ensuring flexibility and efficiency in the development process.
+
+---
+
+## Required Repository Setting for Automated PR Workflows
+
+For the automerge workflow (and other bot-created PRs like Dependabot, `update_template_deps`, `update_template_workflows`) to run their CI checks **automatically without manual approval**, you must configure the following setting in your **generated project's repository**:
+
+1. Go to **Settings → Actions → General**
+2. Under **"Fork pull request workflows from outside collaborators"**, select:
+   - **"Require approval for first-time contributors who are new to GitHub"** (recommended), or
+   - **"Read‑only"** (if you trust all contributors)
+
+Without this setting, PRs created by bots will show **"X workflows awaiting approval"** and their checks will remain blocked until a maintainer manually approves each run.
+
+This setting only needs to be configured once per generated repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-science-project-template"
-version = "1.3.0"
+version = "1.4.0"
 description = "A modern template for data science projects with all the necessary tools for experiment, development, testing, and deployment. From notebooks to production."
 authors = [
     {name = "Jose R. Zapata", email = "https://joserzapata.github.io/"},

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ toml = [
 
 [[package]]
 name = "data-science-project-template"
-version = "1.3.0"
+version = "1.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pre-commit" },

--- a/{{cookiecutter.repo_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.repo_name}}/.github/dependabot.yml
@@ -9,10 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-type: "development"
+      day: "sunday"
+      time: "00:00"
+      timezone: "UTC"
     groups:
-      dev-tools:
+      python-packages:
         patterns:
           - "*"
     commit-message:
@@ -23,6 +24,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "00:00"
+      timezone: "UTC"
     commit-message:
       prefix: ⬆
     labels:

--- a/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
@@ -1,19 +1,21 @@
 name: automerge
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 1-6' # Daily at 08:00 UTC, Mon-Sat
+    - cron: '0 * * * 0'   # Hourly on Sunday to catch up with staggered PR-creating jobs
   workflow_dispatch:
-#{% raw %}
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - id: automerge
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_METHOD: squash
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_LABELS: automerge   # label to trigger automerge
-#{% endraw %}

--- a/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
@@ -15,7 +15,7 @@ jobs:
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ github.token }}"
+          GITHUB_TOKEN: "${{{{ github.token }}}}"
           MERGE_METHOD: squash
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_LABELS: automerge   # label to trigger automerge

--- a/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/automerge.yml
@@ -15,7 +15,9 @@ jobs:
         name: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{{{ github.token }}}}"
+          #{% raw %}
+          GITHUB_TOKEN: "${{ github.token }}"
+          #{% endraw %}
           MERGE_METHOD: squash
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_LABELS: automerge   # label to trigger automerge


### PR DESCRIPTION
## ✨ Context

This PR adds Dependabot configuration for automatic GitHub Actions version updates in both root and template workflows, with staggered schedules to avoid collisions. It also includes a script to update GitHub Actions references in template workflows, a weekly workflow to run the script, and a pre-commit hook to validate Dependabot configuration. The automerge workflow is updated to run hourly on Sundays and daily Monday-Saturday, using github.token and proper permissions. The template versions of these files are also kept in sync.

## 🧠 Rationale behind the change

To prevent PRs from becoming out-of-date due to simultaneous workflow runs, we stagger the schedules and make automerge more responsive. This reduces the need for manual "Update branch" actions.

## Type of changes

- [x] ✨ New Feature (changes that introduce new functionality)
- [ ] 🐛 Bugfix
- [ ] 💥 Breaking Change
- [ ] ⚗️  Experiments
- [ ] 📝 Documentation
- [ ] 🔥 Improvements
- [ ] ✅ Tests
- [ ] 👷 🔧 CI or Configuration Files
- [ ] Other (Please describe)

## 🛠 What does this PR implement

- Adds Dependabot configuration for automatic GitHub Actions version updates in both root and template workflows (with staggered schedules to avoid collisions)
- Adds script `scripts/update_template_workflows.py` to update GitHub Actions references in template workflows
- Adds workflow `.github/workflows/update_template_workflows.yml` to run the update script weekly
- Adds pre-commit hook `check-dependabot` to validate Dependabot configuration before commit
- Updates `.github/workflows/automerge.yml` to run hourly on Sundays and daily Monday-Saturday, using `github.token` and proper permissions
- Updates template's `.github/dependabot.yml` and `.github/workflows/automerge.yml` to match root configuration
- Staggered cron schedules: Dependabot and update_template_deps at 00:00 UTC Sunday, update_template_workflows at 01:00 UTC Sunday, automerge hourly on Sunday and daily 08:00 UTC Mon-Sat

## 🙈 Missing

None

## 🧪 How should this be tested?

- `uv run pytest --cov`

## Summary by Sourcery

Stagger GitHub Actions automation schedules to reduce stale-branch collisions and keep template workflows aligned with the root configuration.

CI:
- Adjust automerge workflow schedules to run hourly on Sundays and daily Monday–Saturday, with appropriate permissions and use of github.token.
- Align Dependabot update schedules in root and template configs to run at a fixed weekly Sunday 00:00 UTC time.
- Stagger the template workflow update job to run weekly on Sunday at 01:00 UTC after dependency update jobs.
- Rename the template Dependabot group from dev-tools to python-packages to match the root configuration.