### PR TITLE
ci: skip dependency-review on private repositories

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,8 @@ permissions:
 
 jobs:
   dependency-review:
+    # Dependency review requires GitHub Advanced Security, only available on public repositories
+    if: github.event.repository.private != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/{{cookiecutter.repo_name}}/.github/workflows/dependency-review.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/dependency-review.yml
@@ -6,6 +6,8 @@ permissions:
 
 jobs:
   dependency-review:
+    # Dependency review requires GitHub Advanced Security, only available on public repositories
+    if: github.event.repository.private != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Title

## ✨ Context

Dependency review requires GitHub Advanced Security, which is only available (free) on public repositories. On private repositories the `dependency-review` check always fails with:

> Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled along with GitHub Advanced Security

## 🧠 Rationale behind the change

Add an `if` condition at job level so the workflow is skipped (`skipped` = green check) on private repos, and still runs normally when a project repository is public. This avoids permanently failing checks in every private repo created from this template.

## Type of changes

- [x] 👷 🔧 CI or Configuration Files

## 🛠 What does this PR implement

- Add `if: github.event.repository.private != true` to the `dependency-review` job in `.github/workflows/dependency-review.yml`

## Summary by Sourcery

CI:
- Skip the dependency-review job for private repositories while continuing to run it for public repositories in both the source workflow and generated repository template.